### PR TITLE
sna_display: Fix cursor screen edge test

### DIFF
--- a/src/sna/sna_display.c
+++ b/src/sna/sna_display.c
@@ -4983,7 +4983,7 @@ sna_set_cursor_position(ScrnInfoPtr scrn, int x, int y)
 {
 	xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(scrn);
 	struct sna *sna = to_sna(scrn);
-	int sigio, c;
+	int sigio, c, xu, yu;
 
 	__DBG(("%s(%d, %d), cursor? %d\n", __FUNCTION__,
 	       x, y, sna->cursor.ref!=NULL));
@@ -5033,8 +5033,8 @@ sna_set_cursor_position(ScrnInfoPtr scrn, int x, int y)
 			arg.y = y - crtc->y;
 		}
 
-		arg.x += sna_crtc->kmode.hskew >> 8;
-		arg.y += sna_crtc->kmode.hskew & 0xFF;
+		xu = sna_crtc->kmode.hskew >> 8;
+		yu = sna_crtc->kmode.hskew & 0xFF;
 
 		if (arg.x < crtc->mode.HDisplay && arg.x > -sna->cursor.size &&
 		    arg.y < crtc->mode.VDisplay && arg.y > -sna->cursor.size) {
@@ -5052,6 +5052,8 @@ sna_set_cursor_position(ScrnInfoPtr scrn, int x, int y)
 				arg.handle = cursor->handle;
 			}
 
+			arg.x += xu;
+			arg.y += yu;
 			arg.width = arg.height = cursor->size;
 			arg.flags |= DRM_MODE_CURSOR_MOVE;
 			crtc->cursor_in_range = true;


### PR DESCRIPTION
When overscan is enabled, the test for when the cursor is off the
screen was incorrect, causing the cursor to disappear near the
bottom and right edges of the screen. Test the cursor position
before translating by the overscan border to correctly determine
if the cursor is visible.

[endlessm/eos-shell#5145]