### PR TITLE
Fix valgrind check

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,9 +8,9 @@ export CPPFLAGS := $(shell dpkg-buildflags --get CPPFLAGS)
 export CFLAGS := $(shell dpkg-buildflags --get CFLAGS)
 export LDFLAGS := $(shell dpkg-buildflags --get LDFLAGS)
 
-DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
+DEB_HOST_ARCH_OS ?= $(shell dpkg-architecture -qDEB_HOST_ARCH_OS)
 
-ifeq ($(DEB_HOST_ARCH), linux)
+ifeq ($(DEB_HOST_ARCH_OS), linux)
 valgrind = --enable-valgrind
 else
 valgrind = --disable-valgrind


### PR DESCRIPTION
Backport a Debian fix from 2:2.99.917-2 packaging.

  [ Timo Aaltonen ]
  * rules: Fix valgrind-enabling check.

For some reason, the behaviour here changed recently, meaning that new
builds no longer have valgrind support enabled.

This innocent-sounding change highlights a bug in an ioctl codepath
causing a driver crash.

[endlessm/eos-shell#5771]