### PR TITLE
Avoid any high-DPI resolutions >= 2560x1440.

### DIFF
--- a/src/sna/sna_display.c
+++ b/src/sna/sna_display.c
@@ -3108,7 +3108,7 @@ prefer_non_hidpi(xf86OutputPtr output, DisplayModePtr Modes)
 		return;
 
 	/* Check if hiDPI */
-	if (preferred->HDisplay != 3840 || preferred->VDisplay != 2160)
+	if (preferred->HDisplay < 2560 || preferred->VDisplay < 1440)
 		return;
 
 	/* Find new preferred mode */


### PR DESCRIPTION
Previously, we only avoided 3840x2160, but the Lenovo Yoga 3
for instance has native resolution of 3200x1800.

https://phabricator.endlessm.com/T10817