### PR TITLE
sna: always flush in sna_flush_callback()

### DIFF
--- a/src/sna/sna_accel.c
+++ b/src/sna/sna_accel.c
@@ -17402,8 +17402,16 @@ sna_flush_callback(CallbackListPtr *list, pointer user_data, pointer call_data)
 {
 	struct sna *sna = user_data;
 
+/*
+ * FIXME: this optimization causes several glitches in apps that use gtkglsink
+ *        https://phabricator.endlessm.com/T14972
+ *
+ * https://cgit.freedesktop.org/~ickle/mesa/commit/?h=dri2&id=0848d39f6fbeca17c412c8b92e147c1b03dd7dfa
+ * should in theory fix this issues but it does not currently work with the mesa version we use.
+ *
 	if (!sna->needs_dri_flush)
 		return;
+ */
 
 	sna_accel_flush(sna);
 	sna->needs_dri_flush = false;


### PR DESCRIPTION
To avoid glitches on apps that use gtkglsink we disabled the optimization.
    
The glitch was introduced by commit 1f6dfc9df6780bd3768bf065156b6e8dae05b80c
"sna: Only flush GPU bo for a damage event"

This patch should be reverted once this issue is properly fixed in mesa
(See https://cgit.freedesktop.org/~ickle/mesa/commit/?h=dri2&id=0848d39f6fbeca17c412c8b92e147c1b03dd7dfa)

https://phabricator.endlessm.com/T14972