### PR TITLE
add xorg.conf.d file to enable DRI 3 by default

### DIFF
--- a/debian/10-intel.conf
+++ b/debian/10-intel.conf
@@ -1,0 +1,5 @@
+Section "Device"
+	Identifier "Intel"
+	Driver "intel"
+	Option "DRI" "3"
+EndSection

--- a/debian/xserver-xorg-video-intel.dirs
+++ b/debian/xserver-xorg-video-intel.dirs
@@ -1,0 +1,1 @@
+usr/share/X11/xorg.conf.d

--- a/debian/xserver-xorg-video-intel.install
+++ b/debian/xserver-xorg-video-intel.install
@@ -5,3 +5,4 @@ usr/lib/*/libIntelXvMC.so*
 usr/lib/xf86-video-intel/xf86-video-intel-backlight-helper
 usr/share/polkit-1/actions/org.x.xf86-video-intel.backlight-helper.policy
 usr/share/man
+10-intel.conf usr/share/X11/xorg.conf.d


### PR DESCRIPTION
We see flickering in Chrome/Chromium which we believe can be worked
around by enabling DRI 3. Try enabling it and see if life improves.

https://phabricator.endlessm.com/T19571