### PR TITLE
switch from "Driver" to "OutputClass"

### DIFF
--- a/debian/10-intel.conf
+++ b/debian/10-intel.conf
@@ -1,5 +1,6 @@
-Section "Device"
-	Identifier "Intel"
-	Driver "intel"
-	Option "DRI" "3"
+Section "OutputClass"
+   Identifier "Intel Graphics"
+   MatchDriver "i915"
+   Driver "intel"
+   Option "DRI" "3"
 EndSection


### PR DESCRIPTION
This will only enable the DRI 3 option and Intel driver when the
GPU is Intel, and not force the intel driver to be loaded in other
cases when it otherwise would not.

https://phabricator.endlessm.com/T19571